### PR TITLE
Stop the docs from sorting the contents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ pygments_style = None
 
 
 # -- Options for HTML output -------------------------------------------------
+autodoc_member_order = 'bysource'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
Methods and constants were sorting alphabetically when they should be sorted by the order that they are in the source.